### PR TITLE
Provide a more consistent class for profile settings and package specific settings

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -22,7 +22,7 @@ class ProcessedProfile(object):
         self._settings = profile.processed_settings
         self._user_options = profile.options.copy()
 
-        self._package_settings = profile.package_settings
+        self._package_settings = profile._package_settings
         self._env_values = profile.env_values
         # Make sure the paths are normalized first, so env_values can be just a copy
         self._dev_reference = create_reference
@@ -84,9 +84,10 @@ class ConanFileLoader(object):
         tmp_settings = processed_profile._settings.copy()
         if (processed_profile._package_settings and
                 conanfile.name in processed_profile._package_settings):
+            # TODO: Investigate this, maybe I can populate in the update/process_settings function
             # Update the values, keeping old ones (confusing assign)
-            values_tuple = processed_profile._package_settings[conanfile.name]
-            tmp_settings.values = Values.from_list(values_tuple)
+            values_tuple = processed_profile._package_settings[conanfile.name].settings
+            tmp_settings.values = Values.from_list(values_tuple.items())
 
         conanfile.initialize(tmp_settings, processed_profile._env_values)
 

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -22,7 +22,7 @@ class ProcessedProfile(object):
         self._settings = profile.processed_settings
         self._user_options = profile.options.copy()
 
-        self._package_settings = profile.package_settings_values
+        self._package_settings = profile.package_settings
         self._env_values = profile.env_values
         # Make sure the paths are normalized first, so env_values can be just a copy
         self._dev_reference = create_reference

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -81,10 +81,12 @@ class ConanFileLoader(object):
     def _initialize_conanfile(conanfile, processed_profile):
         # Prepare the settings for the loaded conanfile
         # Mixing the global settings with the specified for that name if exist
+        # TODO: Why not make this mix inside the Profile class? I can modify the implementation
+        # TODO:  of Profile::package_settings to return a Profile class mixing the global settings
+        # TODO:  with the specific ones
         tmp_settings = processed_profile._settings.copy()
         if (processed_profile._package_settings and
                 conanfile.name in processed_profile._package_settings):
-            # TODO: Investigate this, maybe I can populate in the update/process_settings function
             # Update the values, keeping old ones (confusing assign)
             values_tuple = processed_profile._package_settings[conanfile.name].settings
             tmp_settings.values = Values.from_list(values_tuple.items())

--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -193,7 +193,7 @@ def _apply_inner_profile(doc, base_profile):
                 raise ConanException("Invalid setting line '%s'" % setting)
             package_name, name, value = get_package_name_value(setting)
             if package_name:
-                base_profile.package_settings[package_name][name] = value
+                base_profile.update_package_settings(package_name, OrderedDict({name: value}))
             else:
                 base_profile.settings[name] = value
 
@@ -285,5 +285,5 @@ def _profile_parse_args(settings, options, envs):
     settings, package_settings = _get_simple_and_package_tuples(settings)
     result.settings = OrderedDict(settings)
     for pkg, values in package_settings.items():
-        result.package_settings[pkg] = OrderedDict(values)
+        result.update_package_settings(pkg, OrderedDict(values))
     return result

--- a/conans/model/profile.py
+++ b/conans/model/profile.py
@@ -56,6 +56,9 @@ class _ProfileSettings(object):
             self.settings = res
 
 
+PackageSettings = _ProfileSettings
+
+
 class Profile(_ProfileSettings):
     """A profile contains a set of setting (with values), environment variables
     """
@@ -63,7 +66,7 @@ class Profile(_ProfileSettings):
     def __init__(self):
         # Sections
         super(Profile, self).__init__()
-        self._package_settings = defaultdict(_ProfileSettings)
+        self._package_settings = defaultdict(PackageSettings)
         self.env_values = EnvValues()
         self.options = OptionsValues()
         self.build_requires = OrderedDict()
@@ -114,4 +117,4 @@ class Profile(_ProfileSettings):
     def update_package_settings(self, name, settings):
         """Mix the specified package settings with the specified profile.
         Specified package settings are prioritized to profile"""
-        self._package_settings.setdefault(name, _ProfileSettings()).update_settings(settings)
+        self._package_settings.setdefault(name, PackageSettings()).update_settings(settings)

--- a/conans/test/unittests/client/conanfile_loader_test.py
+++ b/conans/test/unittests/client/conanfile_loader_test.py
@@ -220,11 +220,15 @@ class MyTest(ConanFile):
         self.assertEqual(recipe.settings.os, "Windows")
 
         # Apply Linux for MyPackage
+        profile = Profile()
+        profile.processed_settings = Settings({"os": ["Windows", "Linux"]})
         profile.update_package_settings("MyPackage", OrderedDict([("os", "Linux")]))
         recipe = loader.load_consumer(conanfile_path, test_processed_profile(profile))
         self.assertEqual(recipe.settings.os, "Linux")
 
         # If the package name is different from the conanfile one, it wont apply
+        profile = Profile()
+        profile.processed_settings = Settings({"os": ["Windows", "Linux"]})
         profile.update_package_settings("OtherPACKAGE", OrderedDict([("os", "Linux")]))
         recipe = loader.load_consumer(conanfile_path, test_processed_profile(profile))
         self.assertIsNone(recipe.settings.os.value)

--- a/conans/test/unittests/client/conanfile_loader_test.py
+++ b/conans/test/unittests/client/conanfile_loader_test.py
@@ -213,23 +213,20 @@ class MyTest(ConanFile):
         # Apply windows for MyPackage
         profile = Profile()
         profile.processed_settings = Settings({"os": ["Windows", "Linux"]})
-        profile.package_settings = {"MyPackage": OrderedDict([("os", "Windows")])}
+        profile.update_package_settings("MyPackage", OrderedDict([("os", "Windows")]))
         loader = ConanFileLoader(None, TestBufferConanOutput(), ConanPythonRequire(None, None))
 
-        recipe = loader.load_consumer(conanfile_path,
-                                      test_processed_profile(profile))
+        recipe = loader.load_consumer(conanfile_path, test_processed_profile(profile))
         self.assertEqual(recipe.settings.os, "Windows")
 
         # Apply Linux for MyPackage
-        profile.package_settings = {"MyPackage": OrderedDict([("os", "Linux")])}
-        recipe = loader.load_consumer(conanfile_path,
-                                      test_processed_profile(profile))
+        profile.update_package_settings("MyPackage", OrderedDict([("os", "Linux")]))
+        recipe = loader.load_consumer(conanfile_path, test_processed_profile(profile))
         self.assertEqual(recipe.settings.os, "Linux")
 
         # If the package name is different from the conanfile one, it wont apply
-        profile.package_settings = {"OtherPACKAGE": OrderedDict([("os", "Linux")])}
-        recipe = loader.load_consumer(conanfile_path,
-                                      test_processed_profile(profile))
+        profile.update_package_settings("OtherPACKAGE", OrderedDict([("os", "Linux")]))
+        recipe = loader.load_consumer(conanfile_path, test_processed_profile(profile))
         self.assertIsNone(recipe.settings.os.value)
 
 

--- a/conans/test/unittests/client/profile_loader/package_settings_test.py
+++ b/conans/test/unittests/client/profile_loader/package_settings_test.py
@@ -1,0 +1,60 @@
+# coding=utf-8
+
+import os
+import textwrap
+import unittest
+
+from conans.client.cache.cache import ClientCache
+from conans.client.profile_loader import profile_from_args
+from conans.test.utils.test_files import temp_folder
+from conans.test.utils.tools import TestBufferConanOutput
+from conans.util.files import save
+
+
+class SettingsCppStdTests(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp_folder = temp_folder()
+        self.cache = ClientCache(self.tmp_folder, TestBufferConanOutput())
+
+    def test_compiler(self):
+        profile = textwrap.dedent("""
+            [settings]
+            zlib:compiler=gcc
+            compiler=Visual Studio
+            """)
+        save(os.path.join(self.cache.profiles_path, 'default'), profile)
+        r = profile_from_args(["default", ], [], [], [], cwd=self.tmp_folder, cache=self.cache)
+        r.process_settings(self.cache)
+
+        zlib_profile = r.package_settings("zlib")
+        self.assertEqual(r.settings["compiler"], "Visual Studio")
+        self.assertEqual(zlib_profile.settings["compiler"], "gcc")
+
+    def test_fail_compiler(self):
+        profile = textwrap.dedent("""
+            [settings]
+            zlib:compiler.libcxx=gcc
+            compiler=Visual Studio
+            """)
+        save(os.path.join(self.cache.profiles_path, 'default'), profile)
+        r = profile_from_args(["default", ], [], [], [], cwd=self.tmp_folder, cache=self.cache)
+        r.process_settings(self.cache)
+
+        zlib_profile = r.package_settings("zlib")
+        self.assertEqual(r.settings["compiler"], "Visual Studio")
+        self.assertEqual(zlib_profile.settings["compiler"], "gcc")
+
+    def test_fail_value(self):
+        profile = textwrap.dedent("""
+            [settings]
+            zlib:compiler=tralala
+            compiler=Visual Studio
+            """)
+        save(os.path.join(self.cache.profiles_path, 'default'), profile)
+        r = profile_from_args(["default", ], [], [], [], cwd=self.tmp_folder, cache=self.cache)
+        r.process_settings(self.cache)
+
+        zlib_profile = r.package_settings("zlib")
+        self.assertEqual(r.settings["compiler"], "Visual Studio")
+        self.assertEqual(zlib_profile.settings["compiler"], "gcc")

--- a/conans/test/unittests/client/profile_loader/profile_loader_test.py
+++ b/conans/test/unittests/client/profile_loader/profile_loader_test.py
@@ -136,7 +136,8 @@ class ProfileTest(unittest.TestCase):
     compiler=Visual Studio
     '''
         new_profile, _ = self._get_profile(tmp, prof)
-        self.assertEqual(new_profile.package_settings["zlib"], {"compiler": "gcc"})
+        self.assertEqual(new_profile.package_settings("zlib").settings.keys(), ["compiler"])
+        self.assertEqual(new_profile.package_settings("zlib").settings["compiler"], "gcc")
         self.assertEqual(new_profile.settings["compiler"], "Visual Studio")
 
     def test_empty_env(self):

--- a/conans/test/unittests/model/profile_test.py
+++ b/conans/test/unittests/model/profile_test.py
@@ -61,11 +61,11 @@ MyPackage:os=Windows
 '''
         np, _ = _load_profile(prof, None, None)
 
-        np.update_package_settings({"MyPackage": [("OTHER", "2")]})
+        np._update_package_settings({"MyPackage": [("OTHER", "2")]})
         self.assertEqual(np.package_settings_values,
                          {"MyPackage": [("os", "Windows"), ("OTHER", "2")]})
 
-        np.update_package_settings({"MyPackage": [("compiler", "2"), ("compiler.version", "3")]})
+        np._update_package_settings({"MyPackage": [("compiler", "2"), ("compiler.version", "3")]})
         self.assertEqual(np.package_settings_values,
                          {"MyPackage": [("os", "Windows"), ("OTHER", "2"),
                                         ("compiler", "2"), ("compiler.version", "3")]})

--- a/conans/test/unittests/model/profile_test.py
+++ b/conans/test/unittests/model/profile_test.py
@@ -61,19 +61,19 @@ MyPackage:os=Windows
 '''
         np, _ = _load_profile(prof, None, None)
 
-        np._update_package_settings({"MyPackage": [("OTHER", "2")]})
-        self.assertEqual(np.package_settings_values,
-                         {"MyPackage": [("os", "Windows"), ("OTHER", "2")]})
+        np.update_package_settings("MyPackage", OrderedDict([("OTHER", "2")]))
+        self.assertEqual(np.package_settings("MyPackage").settings,
+                         OrderedDict([('os', 'Windows'), ('OTHER', '2')]))
 
-        np._update_package_settings({"MyPackage": [("compiler", "2"), ("compiler.version", "3")]})
-        self.assertEqual(np.package_settings_values,
-                         {"MyPackage": [("os", "Windows"), ("OTHER", "2"),
-                                        ("compiler", "2"), ("compiler.version", "3")]})
+        np.update_package_settings("MyPackage", OrderedDict([("compiler", "2"), ("compiler.version", "3")]))
+        self.assertEqual(np.package_settings("MyPackage").settings,
+                         OrderedDict([('os', 'Windows'), ('OTHER', '2'),
+                                      ('compiler', '2'), ('compiler.version', '3')]))
 
     def profile_dump_order_test(self):
         # Settings
         profile = Profile()
-        profile.package_settings["zlib"] = {"compiler": "gcc"}
+        profile.update_package_settings("zlib", OrderedDict({"compiler": "gcc"}))
         profile.settings["arch"] = "x86_64"
         profile.settings["compiler"] = "Visual Studio"
         profile.settings["compiler.version"] = "12"

--- a/conans/test/utils/profiles.py
+++ b/conans/test/utils/profiles.py
@@ -14,7 +14,8 @@ def create_profile(folder, name, settings=None, package_settings=None, env=None,
     profile.settings = settings or {}
 
     if package_settings:
-        profile.package_settings = package_settings
+        for pkg_name, values in package_settings.items():
+            profile.update_package_settings(pkg_name, values)
 
     if options:
         profile.options = OptionsValues(options)


### PR DESCRIPTION
Changelog: omit
Docs: omit

I'm making this little refactoring to help me on https://github.com/conan-io/conan/pull/4917, with this refactor both the validation of the _main_ settings and the settings scoped for a package is done at the beginning of the execution (during the `process_settings` call), validation of the last ones was being delayed until the graph.

It is basically encapsulating the member variable `Profile::package_settings` and changing it from `dict(OrderedDict)` to `dict(_ProfileSettings)`. This new class `_ProfileSettings` handles the settings for the general graph or for a specific package; `Profile` class now inherits from it to implement the `options`, `env` and `build_requires` like it was before.

Pending:

- [ ] Can we get rid of `ProcessedProfile`? I think that this class is just a view over the actual `Profile` with the extra of a member variable `_dev_reference` which is consumed inside the Graph to know which reference should set `conanfile.develop = True`. -> https://github.com/conan-io/conan/pull/4921

- [ ] [This](https://github.com/conan-io/conan/compare/develop...jgsogo:refact/package_settings?expand=1#diff-adc6a79aace221d12df156da777e6904R87) can be simplied

- [ ] Check docstring of `Profile` functions

----

@tags: slow  (I want to run every test using profiles, settings,...)